### PR TITLE
Support for Kerala data

### DIFF
--- a/automation/automation.meta
+++ b/automation/automation.meta
@@ -2,7 +2,7 @@ Andhra Pradesh, AP, http://covid19.ap.gov.in/Covid19_Admin/api/CV/DashboardCount
 Odisha, OR, https://health.odisha.gov.in/js/distDtls.js
 Rajasthan, RJ, http://www.rajswasthya.nic.in/
 Maharashtra, MH, https://services5.arcgis.com/h1qecetkQkV9PbPV/arcgis/rest/services/COVID19_Location_Summary/FeatureServer/0/query?f=json&where=1%3D1&returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*
-#Telangana, TS, 
+#Telangana, TS,
 Gujarat, GJ,https://gujcovid19.gujarat.gov.in/DrillDownCharts.aspx/GetDistDataForLineCovidDisrtict
 Uttar Pradesh, UP,
 Bihar, BR,
@@ -11,7 +11,7 @@ Assam, AS, https://covid19.assam.gov.in/all-districts/
 Tripura, TR, https://covid19.tripura.gov.in/Visitor/ViewStatus.aspx
 Puducherry, PY, https://covid19dashboard.py.gov.in/Reporting/DateWise
 Chandigarh, CH, http://chdcovid19.in/
-#Kerala, KL, https://dashboard.kerala.gov.in/dailyreporting.php
+Kerala, KL, https://dashboard.kerala.gov.in/maps/outside.geojson
 Ladakh, LA, http://covid.ladakh.gov.in/#dataInsights
 Punjab, PB,
 Tamil Nadu, TN,

--- a/automation/automation.py
+++ b/automation/automation.py
@@ -575,24 +575,36 @@ def CHGetData():
 
 
 def KLGetData():
-	response = requests.request("GET", metaDictionary['Kerala'].url)
-	soup = BeautifulSoup(response.content, 'html.parser')
-	table = soup.find_all("script")
+	#TODO : Need to check if the sessionid expires and look into possible workarounds if it does
+	cookies = {
+		'_ga': 'GA1.3.594771251.1592531338',
+		'_gid': 'GA1.3.674470591.1592531338',
+		'PHPSESSID': 'a87c5dce18c37488e5aa48742695f52a',
+		'_gat_gtag_UA_162482846_1': '1',
+	}
 
-	klData = open("kl.txt", "w")
-	klData.writelines(table[len(table) - 1].get_text())
-	klData.close()
-	districtList = ""
+	headers = {
+		'Connection': 'keep-alive',
+		'Accept': 'application/json, text/javascript, */*; q=0.01',
+		'X-Requested-With': 'XMLHttpRequest',
+		'Sec-Fetch-Site': 'same-origin',
+		'Sec-Fetch-Mode': 'cors',
+		'Sec-Fetch-Dest': 'empty',
+		'Referer': 'https://dashboard.kerala.gov.in/index.php',
+		'Accept-Language': 'en-US,en;q=0.9',
+	}
 
-	with open("kl.txt", "r") as klFile:
-		for line in klFile:
-			if "labels:" in line:
-				print(line)
-				distrctList = re.sub("labels: ", "", line)
-				print(line)
-			if "data:" in line: 
-				print(line)
-	klFile.close()
+	stateDashboard = requests.get(metaDictionary['Kerala'].url, headers=headers, cookies=cookies).json()
+	districtArray = []
+	for districtDetails in stateDashboard['features']:
+		districtDictionary = {}
+		districtDictionary['districtName'] = districtDetails['properties']['District']
+		districtDictionary['confirmed'] = districtDetails['properties']['covid_stat']
+		districtDictionary['recovered'] = districtDetails['properties']['covid_statcured']
+		districtDictionary['deceased'] = districtDetails['properties']['covid_statdeath']
+		districtArray.append(districtDictionary)
+	deltaCalculator.getStateDataFromSite("Kerala", districtArray, option)
+
 
 def LAGetData():
 	response = requests.request("GET", metaDictionary['Ladakh'].url)

--- a/automation/automation.py
+++ b/automation/automation.py
@@ -583,11 +583,13 @@ def CHGetData():
 
 
 def KLGetData():
-	#TODO : Need to check if the sessionid expires and look into possible workarounds if it does
+	response = requests.request("GET", 'https://dashboard.kerala.gov.in/index.php')
+	sessionId = (response.headers['Set-Cookie']).split(';')[0].split('=')[1]
+
 	cookies = {
 		'_ga': 'GA1.3.594771251.1592531338',
 		'_gid': 'GA1.3.674470591.1592531338',
-		'PHPSESSID': 'a87c5dce18c37488e5aa48742695f52a',
+		'PHPSESSID': sessionId,
 		'_gat_gtag_UA_162482846_1': '1',
 	}
 

--- a/automation/nameMapping.meta
+++ b/automation/nameMapping.meta
@@ -46,3 +46,5 @@ Karnataka, Bellary, Ballari
 Karnataka, Ramanagar, Ramanagara
 Karnataka, Kalaburgi, Kalaburagi
 Karnataka, Kalburgi, Kalaburagi
+Kerala, Kasargod, Kasaragod
+Kerala, Kozhikkode, Kozhikode


### PR DESCRIPTION
**Description of PR**
Added support for data from Kerala dashboard. Using response from endpoint https://dashboard.kerala.gov.in/maps/outside.geojson. 

_Note :_ The dashboard expects a cookie session id to be sent with the request. Have hardcoded it in the code. Doesn't seem to have an expiration based on testing so far. Need to add a workaround if we find out that it does expire after some time.  

Fixes #4  