### PR TITLE
Add fuzzy logic to map districts if exact match fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ automation/ocr/ocrconfig.meta
 venv/
 __pycache__
 !requirements.txt
+
+.vscode

--- a/automation/ocr/googlevision.py
+++ b/automation/ocr/googlevision.py
@@ -433,12 +433,39 @@ def printOutput():
 							outputString += "," + value.strip()
 					print("{} | {}".format(outputString, columnList), file = outputFile)
 				except KeyError:
-					print("Failed to find lookup for {} ".format(districtName))  
+					try:
+						fuzzyDistrict = fuzzyLookup(translationDictionary,districtName)
+						translatedValue = translationDictionary[fuzzyDistrict]
+					except:
+						print(f"Failed to find lookup for {districtName}")
+						continue
+					
+				outputString = translatedValue 
+				for index, value in enumerate(outputArray):
+					if index > districtIndex:
+						outputString += "," + value.strip()
+				print("{} | {}".format(outputString, columnList), file = outputFile)
+
 	outputFile.close()
 	ax.imshow(image)
 	plt.savefig("image.png", dpi=300)
 	plt.show()
 
+def fuzzyLookup(translationDictionary,districtName):
+	'''
+	Use fuzzy string match to map incorrect districtnames
+	to the ones in the dictionary
+	'''
+	from fuzzywuzzy import process
+	# Score cut-off of 90 seem to be working well for UP
+	district = process.extractOne(
+		districtName,
+		translationDictionary.keys(),
+		score_cutoff = 90)[0]
+	print(f"WARN : {districtName} mapped to {district} using Fuzzy Lookup")
+	return district
+
+	
 def parseConfigFile(fileName):
 	global startingText
 	global endingText

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,5 @@ sortedcontainers==2.2.2
 soupsieve==2.0.1
 urllib3==1.25.9
 webencodings==0.5.1
+fuzzywuzzy==0.18.0
+python-Levenshtein==0.12.0


### PR DESCRIPTION
District name lookup from output from OCR updated with a fuzzy logic when direct lookup fails. Current threshold set of match is 90 in Levenshtein distance. There is a low probability that this causes undesired mappings though. Hence a Warning is generated when such a mapping is done.

Stack trace on a test case (https://twitter.com/sengarlive/status/1286971767160885249) : 

```
c20 ... 731,1155 --> 765,1155
c21 ... 765,1155 --> 811,1155
c22 ... 811,1155 --> 867,1155
r1 ... 338,17 --> 78,33
r2 ... 78,33 --> 80,1155
Starting text: लखनऊ ... Ending text: बहराइच
Using computed yInterval: 10.0, xInterval: 3
**WARN : बध नगर mapped to बुध नगर using Fuzzy Lookup
WARN : नगर mapped to गौतम बुद्ध नगर using Fuzzy Lookup
WARN : नगर mapped to गौतम बुद्ध नगर using Fuzzy Lookup
WARN : - खीरी mapped to खीरी using Fuzzy Lookup**

******** Calling automation.py for Uttar Pradesh  ******* 
Using pageId: 
--> Issue with ['Unnao', '22', '10', '292', '13', '293 ']
--> Issue with ['Unnao', '22', '10', '292', '13', '293 ']

********************Uttar Pradesh********************
Lucknow,Uttar Pradesh,UP,-767,Hospitalized
Lucknow,Uttar Pradesh,UP,-767,Hospitalized

```

Updated requirements and .gitignore for maintenance

