### PR TITLE
Hotfix : Remove dual printing into output.txt

### DIFF
--- a/automation/ocr/googlevision.py
+++ b/automation/ocr/googlevision.py
@@ -431,7 +431,6 @@ def printOutput():
 					for index, value in enumerate(outputArray):
 						if index > districtIndex: #and is_number(value):
 							outputString += "," + value.strip()
-					print("{} | {}".format(outputString, columnList), file = outputFile)
 				except KeyError:
 					try:
 						fuzzyDistrict = fuzzyLookup(translationDictionary,districtName)


### PR DESCRIPTION
I had not removed the original print statement in my PR. This caused district names to be printed twice in the output.txt. Fixed that.